### PR TITLE
Add dashboard charts

### DIFF
--- a/master/app/(dashboard)/[storeId]/(routes)/mock-data.ts
+++ b/master/app/(dashboard)/[storeId]/(routes)/mock-data.ts
@@ -1,0 +1,38 @@
+export interface OrderTrendDataPoint {
+  date: string;
+  orders: number;
+  revenue: number;
+}
+
+export interface ProductSalesData {
+  name: string;
+  sales: number;
+}
+
+export interface InventoryItem {
+  product: string;
+  stock: number;
+}
+
+export const orderTrendData: OrderTrendDataPoint[] = [
+  { date: "2024-06-01", orders: 14, revenue: 240 },
+  { date: "2024-06-02", orders: 20, revenue: 420 },
+  { date: "2024-06-03", orders: 12, revenue: 210 },
+  { date: "2024-06-04", orders: 18, revenue: 350 },
+  { date: "2024-06-05", orders: 25, revenue: 500 },
+  { date: "2024-06-06", orders: 30, revenue: 620 },
+  { date: "2024-06-07", orders: 22, revenue: 410 },
+];
+
+export const topProducts: ProductSalesData[] = [
+  { name: "Shirt", sales: 120 },
+  { name: "Pants", sales: 90 },
+  { name: "Hat", sales: 75 },
+  { name: "Shoes", sales: 60 },
+  { name: "Jacket", sales: 50 },
+];
+
+export const lowInventory: InventoryItem[] = [
+  { product: "Shirt", stock: 3 },
+  { product: "Hat", stock: 5 },
+];

--- a/master/app/(dashboard)/[storeId]/(routes)/page.tsx
+++ b/master/app/(dashboard)/[storeId]/(routes)/page.tsx
@@ -1,24 +1,25 @@
 "use client";
-import ImageUpload from "@/components/ui/image-upload";
-import { useState } from "react";
+import {
+  orderTrendData,
+  topProducts,
+  lowInventory,
+} from "./mock-data";
+import { OrderVolumeChart } from "@/components/dashboard/OrderVolumeChart";
+import { RevenueChart } from "@/components/dashboard/RevenueChart";
+import { AOVCard } from "@/components/dashboard/AOVCard";
+import { TopProductsChart } from "@/components/dashboard/TopProductsChart";
+import { InventoryAlert } from "@/components/dashboard/InventoryAlert";
 
 const DashboardPage = () => {
-  const [loading, setLoading] = useState(false);
-  const [imageUrls, setImageUrls] = useState<string[]>([]);
-
-  const handleImageChange = (urls: string[]) => {
-    setImageUrls(urls);
-  };
-
-  const handleImageRemove = (urls: string[]) => {
-    setImageUrls(urls);
-  };
-
   return (
-    <div>
-      This will be a dashboard!
-      {/*TODO: Add Visual Graphs for the store, such as products sold, revenue, etc.*/}
-      {/*TODO: Add a Sales page for the webapp where users can load their sales in a csv format and upload it to the database*/}
+    <div className="p-6 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div className="md:col-span-2 lg:col-span-3">
+        <InventoryAlert items={lowInventory} />
+      </div>
+      <OrderVolumeChart data={orderTrendData} />
+      <RevenueChart data={orderTrendData} />
+      <AOVCard data={orderTrendData} />
+      <TopProductsChart data={topProducts} />
     </div>
   );
 };

--- a/master/components/dashboard/AOVCard.tsx
+++ b/master/components/dashboard/AOVCard.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { OrderTrendDataPoint } from "@/app/(dashboard)/[storeId]/(routes)/mock-data";
+import { ResponsiveContainer, LineChart, Line } from "recharts";
+
+interface AOVCardProps {
+  data: OrderTrendDataPoint[];
+}
+
+export function AOVCard({ data }: AOVCardProps) {
+  const totalOrders = data.reduce((acc, d) => acc + d.orders, 0);
+  const totalRevenue = data.reduce((acc, d) => acc + d.revenue, 0);
+  const aov = totalOrders ? totalRevenue / totalOrders : 0;
+
+  const sparkData = data.map((d) => ({ date: d.date, value: d.revenue / d.orders }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Average Order Value</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-3xl font-bold">{aov.toFixed(2)}</div>
+        <div className="h-24 mt-2">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={sparkData}>
+              <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/master/components/dashboard/InventoryAlert.tsx
+++ b/master/components/dashboard/InventoryAlert.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import type { InventoryItem } from "@/app/(dashboard)/[storeId]/(routes)/mock-data";
+
+interface InventoryAlertProps {
+  items: InventoryItem[];
+}
+
+export function InventoryAlert({ items }: InventoryAlertProps) {
+  if (items.length === 0) return null;
+  return (
+    <Alert variant="destructive">
+      <AlertTitle>Low Stock</AlertTitle>
+      <AlertDescription>
+        <ul className="list-disc pl-4 space-y-1">
+          {items.map((item) => (
+            <li key={item.product}>
+              {item.product}: {item.stock} left
+            </li>
+          ))}
+        </ul>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/master/components/dashboard/OrderVolumeChart.tsx
+++ b/master/components/dashboard/OrderVolumeChart.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { OrderTrendDataPoint } from "@/app/(dashboard)/[storeId]/(routes)/mock-data";
+
+interface OrderVolumeChartProps {
+  data: OrderTrendDataPoint[];
+}
+
+export function OrderVolumeChart({ data }: OrderVolumeChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Order Volume</CardTitle>
+      </CardHeader>
+      <CardContent className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} className="text-sm">
+            <XAxis dataKey="date" className="fill-muted-foreground" />
+            <YAxis allowDecimals={false} className="fill-muted-foreground" />
+            <Tooltip wrapperClassName="!text-xs" />
+            <Bar dataKey="orders" fill="hsl(var(--primary))" className="rounded" />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/master/components/dashboard/RevenueChart.tsx
+++ b/master/components/dashboard/RevenueChart.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { OrderTrendDataPoint } from "@/app/(dashboard)/[storeId]/(routes)/mock-data";
+
+interface RevenueChartProps {
+  data: OrderTrendDataPoint[];
+}
+
+export function RevenueChart({ data }: RevenueChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sales Revenue</CardTitle>
+      </CardHeader>
+      <CardContent className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} className="text-sm">
+            <XAxis dataKey="date" className="fill-muted-foreground" />
+            <YAxis className="fill-muted-foreground" />
+            <Tooltip wrapperClassName="!text-xs" />
+            <Line type="monotone" dataKey="revenue" stroke="hsl(var(--primary))" strokeWidth={2} />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/master/components/dashboard/TopProductsChart.tsx
+++ b/master/components/dashboard/TopProductsChart.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type { ProductSalesData } from "@/app/(dashboard)/[storeId]/(routes)/mock-data";
+
+interface TopProductsChartProps {
+  data: ProductSalesData[];
+}
+
+export function TopProductsChart({ data }: TopProductsChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Top Selling Products</CardTitle>
+      </CardHeader>
+      <CardContent className="h-72">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} layout="vertical" className="text-sm">
+            <XAxis type="number" className="fill-muted-foreground" />
+            <YAxis dataKey="name" type="category" width={80} className="fill-muted-foreground" />
+            <Tooltip wrapperClassName="!text-xs" />
+            <Bar dataKey="sales" fill="hsl(var(--primary))" className="rounded" />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/master/components/ui/card.tsx
+++ b/master/components/ui/card.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border bg-card text-card-foreground shadow-sm", className)}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardContent, CardFooter };

--- a/master/package.json
+++ b/master/package.json
@@ -35,6 +35,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.2",
     "react-hot-toast": "^2.5.2",
+    "recharts": "^2.8.0",
     "tailwind-merge": "^3.2.0",
     "ws": "^8.18.2",
     "zod": "^3.24.4",


### PR DESCRIPTION
## Summary
- add Recharts dependency
- implement ShadCN card component
- implement reusable dashboard chart components
- add mock data for dashboard analytics
- replace placeholder dashboard page with charts

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683f881aff3083218aa41eed7df8099c